### PR TITLE
Sitio web y cuenta en Github de Raspberry Pi Nicaragua

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,6 +292,7 @@
         <div class="thumbnail">
             <img src="img/raspberry-ni.png" alt="Comunidad Raspberry Nicaragua">
             <ul class="recursos">
+                <li class="web"><a href="https://raspberryni.github.io/website/" title=""> Sitio web</a></li>
                 <li class="correo"><a href="http://listas.softwarelibre.org.ni/listinfo/raspberry-ni" title="Lista de correos de la Comunidad Raspberry Nicaragua"> Lista de correos</a></li>
             </ul>
         </div>
@@ -316,7 +317,7 @@
     <a href="http://2013.nicaragua.wordcamp.org/">WordCamp</a>.</p>
 
 <p>A nivel general, se organizan eventos con la participación de toda la comunidad, como el Festival Nacional de Software Libre, la versión internacional
-    que es el <a href="http://linuxtour.org/flisol">FLISOL</a>, o a nivel centroamericano, el 
+    que es el <a href="http://linuxtour.org/flisol">FLISOL</a>, o a nivel centroamericano, el
             Encuentro Centroamericano de Software Libre.</p>
 
 <p>Los eventos generales de las comunidades de Linux se llevan a cabo bajo la marca <a href="http://linuxtour.org">Linux
@@ -369,9 +370,9 @@
     autores y obtener el código fuente de este sitio web de su <a href="https://github.com/leogg/slorgni">repositorio en
         linea</a>. Por supuesto está invitado a mejorar el sitio por este medio.</p>
 
-<p>Muchas gracias por el gentil apoyo del <a href="http://nic.ni">nic.ni</a> quien nos facilitó el dominio 
-    softwarelibre.org.ni, el <a href="http://www.isic.edu.ni/">Instituto de Informática y Comercio (ISIC)</a> por el 
-    alojamiento web y de <a href="http://www.guegue.com/">G&uuml;eg&uuml;e comunicaciones</a>  por el espacio para 
+<p>Muchas gracias por el gentil apoyo del <a href="http://nic.ni">nic.ni</a> quien nos facilitó el dominio
+    softwarelibre.org.ni, el <a href="http://www.isic.edu.ni/">Instituto de Informática y Comercio (ISIC)</a> por el
+    alojamiento web y de <a href="http://www.guegue.com/">G&uuml;eg&uuml;e comunicaciones</a>  por el espacio para
     nuestro servicio de listas de correo.</p>
 
 <p>Todo el contenido de este sitio está liberado bajo una licencia <a

--- a/index.html
+++ b/index.html
@@ -293,6 +293,7 @@
             <img src="img/raspberry-ni.png" alt="Comunidad Raspberry Nicaragua">
             <ul class="recursos">
                 <li class="web"><a href="https://raspberryni.github.io/website/" title=""> Sitio web</a></li>
+                <li class="web"><a href="https://github.com/raspberryni" title=""> Github</a></li>
                 <li class="correo"><a href="http://listas.softwarelibre.org.ni/listinfo/raspberry-ni" title="Lista de correos de la Comunidad Raspberry Nicaragua"> Lista de correos</a></li>
             </ul>
         </div>


### PR DESCRIPTION
Se agregó sitio web y cuenta de organización en github de la comunidad Raspberry Pi Nicaragua.

Cc: @raspberryni